### PR TITLE
reduce the numbers of metrics sent to DD

### DIFF
--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -119,7 +119,7 @@ function Histogram(key, tags, host) {
     this.sum = 0;
     this.count = 0;
     this.samples = [];
-    this.percentiles = [0.75, 0.85, 0.95, 0.99];
+    this.percentiles = [0.95];
 }
 
 util.inherits(Histogram, Metric);
@@ -140,9 +140,6 @@ Histogram.prototype.addPoint = function(val, timestampInMillis) {
 
 Histogram.prototype.flush = function() {
     var points = [
-        this.serializeMetric(this.min, 'gauge', this.key + '.min'),
-        this.serializeMetric(this.max, 'gauge', this.key + '.max'),
-        this.serializeMetric(this.sum, 'gauge', this.key + '.sum'),
         this.serializeMetric(this.count, 'count', this.key + '.count'),
         this.serializeMetric(this.average(), 'gauge', this.key + '.avg')
     ];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "datadog-metrics",
-  "version": "0.8.1",
+  "version": "2.0.0",
   "description": "Buffered metrics reporting via the DataDog HTTP API",
   "main": "index.js",
   "repository": {

--- a/test/metrics_tests.js
+++ b/test/metrics_tests.js
@@ -103,67 +103,34 @@ describe('Histogram', function() {
         h.updateTimestamp.should.be.a('function');
     });
 
-    it('should report the min and max of all values', function() {
-        var h = new metrics.Histogram('hist');
-        var f = h.flush();
-
-        f.should.have.deep.property('[0].metric', 'hist.min');
-        f.should.have.deep.property('[0].points[0][1]', Infinity);
-        f.should.have.deep.property('[1].metric', 'hist.max');
-        f.should.have.deep.property('[1].points[0][1]', -Infinity);
-
-        h.addPoint(23);
-
-        f = h.flush();
-        f.should.have.deep.property('[0].metric', 'hist.min');
-        f.should.have.deep.property('[0].points[0][1]', 23);
-        f.should.have.deep.property('[1].metric', 'hist.max');
-        f.should.have.deep.property('[1].points[0][1]', 23);
-    });
-
-    it('should report a sum of all values', function() {
-        var h = new metrics.Histogram('hist');
-        var f = h.flush();
-
-        f.should.have.deep.property('[2].metric', 'hist.sum');
-        f.should.have.deep.property('[2].points[0][1]', 0);
-
-        h.addPoint(2);
-        h.addPoint(3);
-
-        f = h.flush();
-        f.should.have.deep.property('[2].metric', 'hist.sum');
-        f.should.have.deep.property('[2].points[0][1]', 5);
-    });
-
     it('should report the number of samples (count)', function() {
         var h = new metrics.Histogram('hist');
         var f = h.flush();
 
-        f.should.have.deep.property('[3].metric', 'hist.count');
-        f.should.have.deep.property('[3].points[0][1]', 0);
+        f.should.have.deep.property('[0].metric', 'hist.count');
+        f.should.have.deep.property('[0].points[0][1]', 0);
 
         h.addPoint(2);
         h.addPoint(3);
 
         f = h.flush();
-        f.should.have.deep.property('[3].metric', 'hist.count');
-        f.should.have.deep.property('[3].points[0][1]', 2);
+        f.should.have.deep.property('[0].metric', 'hist.count');
+        f.should.have.deep.property('[0].points[0][1]', 2);
     });
 
     it('should report the average', function() {
         var h = new metrics.Histogram('hist');
         var f = h.flush();
 
-        f.should.have.deep.property('[4].metric', 'hist.avg');
-        f.should.have.deep.property('[4].points[0][1]', 0);
+        f.should.have.deep.property('[1].metric', 'hist.avg');
+        f.should.have.deep.property('[1].points[0][1]', 0);
 
         h.addPoint(2);
         h.addPoint(3);
 
         f = h.flush();
-        f.should.have.deep.property('[4].metric', 'hist.avg');
-        f.should.have.deep.property('[4].points[0][1]', 2.5);
+        f.should.have.deep.property('[1].metric', 'hist.avg');
+        f.should.have.deep.property('[1].points[0][1]', 2.5);
     });
 
     it('should report the correct percentiles', function() {
@@ -171,14 +138,8 @@ describe('Histogram', function() {
         h.addPoint(1);
         var f = h.flush();
 
-        f.should.have.deep.property('[5].metric', 'hist.75percentile');
-        f.should.have.deep.property('[5].points[0][1]', 1);
-        f.should.have.deep.property('[6].metric', 'hist.85percentile');
-        f.should.have.deep.property('[6].points[0][1]', 1);
-        f.should.have.deep.property('[7].metric', 'hist.95percentile');
-        f.should.have.deep.property('[7].points[0][1]', 1);
-        f.should.have.deep.property('[8].metric', 'hist.99percentile');
-        f.should.have.deep.property('[8].points[0][1]', 1);
+        f.should.have.deep.property('[2].metric', 'hist.95percentile');
+        f.should.have.deep.property('[2].points[0][1]', 1);
 
         // Create 100 samples from [1..100] so we can
         // verify the calculated percentiles.
@@ -187,13 +148,7 @@ describe('Histogram', function() {
         }
         f = h.flush();
 
-        f.should.have.deep.property('[5].metric', 'hist.75percentile');
-        f.should.have.deep.property('[5].points[0][1]', 75);
-        f.should.have.deep.property('[6].metric', 'hist.85percentile');
-        f.should.have.deep.property('[6].points[0][1]', 85);
-        f.should.have.deep.property('[7].metric', 'hist.95percentile');
-        f.should.have.deep.property('[7].points[0][1]', 95);
-        f.should.have.deep.property('[8].metric', 'hist.99percentile');
-        f.should.have.deep.property('[8].points[0][1]', 99);
+        f.should.have.deep.property('[2].metric', 'hist.95percentile');
+        f.should.have.deep.property('[2].points[0][1]', 95);
     });
 });

--- a/test/module_tests.js
+++ b/test/module_tests.js
@@ -30,7 +30,7 @@ describe('datadog-metrics', function() {
             flushIntervalSeconds: 0,
             reporter: {
                 report: function(series, onSuccess, onError) {
-                    series.should.have.length(11); // 3 + 8 for the histogram.
+                    series.should.have.length(5); // 3 + 8 for the histogram.
                     series[0].should.have.deep.property('points[0][1]', 23);
                     series[0].should.have.deep.property('metric', 'test.gauge');
                     series[0].tags.should.have.length(0);


### PR DESCRIPTION
This is the actual lib/location that data is aggregated/analyzed to be sent back to DD.

For the histogram specifically, we don't use about half of the values. I'm removing them here so it helps to reduce the load across the board.

I looked at our "go-to" board: frontend metrics cloned: https://app.datadoghq.com/dashboard/6kr-fyt-s4c/frontend-metrics-cloned?from_ts=1617856482437&live=true&to_ts=1617857382437

It seems like we only use avg, count, 95%.

Please let me know if there is anything else you know we should keep.

Part of: https://redventures.atlassian.net/browse/HLFE-1381